### PR TITLE
improve `pack`

### DIFF
--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -208,7 +208,7 @@ def pack(
     # Adjust cell dimensions according to ratio while keeping volume unchanged
     original_volume = np.prod(cell)
     ratio_product = np.prod(ratio)
-    scale = original_volume ** (1/3) / (ratio_product ** (1/3))
+    scale = original_volume ** (1 / 3) / (ratio_product ** (1 / 3))
     cell = [scale * r for r in ratio]
 
     with tempfile.TemporaryDirectory() as tmpdir_str:

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -76,12 +76,22 @@ def _run_packmol(
             f.write(f'run_packmol("{input_file.name}") \n')
 
     if packmol_executable == "packmol.jl":
-            subprocess.run(["julia", str(tmpdir / "pack.jl")], cwd=tmpdir, check=True, capture_output=not verbose)
+        subprocess.run(
+            ["julia", str(tmpdir / "pack.jl")],
+            cwd=tmpdir,
+            check=True,
+            capture_output=not verbose,
+        )
     else:
         # e.g., run packmol with stdin to avoid shell redirection
         with open(input_file, "rb") as fin:
-            subprocess.run([packmol_executable], cwd=tmpdir, check=True, capture_output=not verbose, stdin=fin)
-
+            subprocess.run(
+                [packmol_executable],
+                cwd=tmpdir,
+                check=True,
+                capture_output=not verbose,
+                stdin=fin,
+            )
 
 
 def _write_molecule_files(

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -212,6 +212,11 @@ def pack(
             print(packmol_input)
         _run_packmol(packmol, tmpdir / "pack.inp", tmpdir, verbose)
         packed_atoms: ase.Atoms = ase.io.read(tmpdir / f"mixture.{output_format}")
+        packed_atoms.arrays.pop("atomtypes", None)
+        packed_atoms.arrays.pop("bfactor", None)
+        packed_atoms.arrays.pop("occupancy", None)
+        packed_atoms.arrays.pop("residuenames", None)
+        packed_atoms.arrays.pop("residuenumbers", None)
 
     packed_atoms.cell = cell
     packed_atoms.pbc = True

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -83,7 +83,6 @@ def _run_packmol(
             capture_output=not verbose,
         )
     else:
-        # e.g., run packmol with stdin to avoid shell redirection
         with open(input_file, "rb") as fin:
             subprocess.run(
                 [packmol_executable],

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -188,8 +188,8 @@ def pack(
         WARNING: Do not use "xyz". This might cause issues and
         is only implemented for debugging purposes.
     ratio : tuple[float, float, float], optional
-        The aspect ratio of the simulation box,
-        by default (1.0, 1.0, 1.0) for a cubic box.
+        Box aspect ratio (a:b:c). Must be three positive, finite numbers.
+        Defaults to (1.0, 1.0, 1.0) for a cubic box.
 
     Returns
     -------
@@ -208,14 +208,16 @@ def pack(
     """
     selected_images = _select_conformers(data, counts, seed)
     cell = calculate_box_dimensions(images=selected_images, density=density)
-    packmol_input = _generate_packmol_input(
-        selected_images, cell, tolerance, seed, output_format, pbc
-    )
+
     # Adjust cell dimensions according to ratio while keeping volume unchanged
     original_volume = np.prod(cell)
     ratio_product = np.prod(ratio)
     scale = original_volume ** (1 / 3) / (ratio_product ** (1 / 3))
-    cell = [scale * r for r in ratio]
+    cell = [float(scale * r) for r in ratio]
+
+    packmol_input = _generate_packmol_input(
+        selected_images, cell, tolerance, seed, output_format, pbc
+    )
 
     with tempfile.TemporaryDirectory() as tmpdir_str:
         tmpdir = pathlib.Path(tmpdir_str)

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -153,6 +153,7 @@ def pack(
     packmol: str = "packmol",
     pbc: bool = True,
     output_format: FORMAT = "pdb",
+    ratio: tuple[float, float, float] = (1.0, 1.0, 1.0),
 ) -> ase.Atoms:
     """
     Packs the given molecules into a box with the specified density using PACKMOL.
@@ -180,6 +181,9 @@ def pack(
         The file format used for communication with packmol, by default "pdb".
         WARNING: Do not use "xyz". This might cause issues and
         is only implemented for debugging purposes.
+    ratio : tuple[float, float, float], optional
+        The aspect ratio of the simulation box,
+        by default (1.0, 1.0, 1.0) for a cubic box.
 
     Returns
     -------
@@ -201,6 +205,11 @@ def pack(
     packmol_input = _generate_packmol_input(
         selected_images, cell, tolerance, seed, output_format, pbc
     )
+    # Adjust cell dimensions according to ratio while keeping volume unchanged
+    original_volume = np.prod(cell)
+    ratio_product = np.prod(ratio)
+    scale = original_volume ** (1/3) / (ratio_product ** (1/3))
+    cell = [scale * r for r in ratio]
 
     with tempfile.TemporaryDirectory() as tmpdir_str:
         tmpdir = pathlib.Path(tmpdir_str)

--- a/rdkit2ase/pack.py
+++ b/rdkit2ase/pack.py
@@ -74,17 +74,14 @@ def _run_packmol(
         with open(tmpdir / "pack.jl", "w") as f:
             f.write("using Packmol \n")
             f.write(f'run_packmol("{input_file.name}") \n')
-        command = f"julia {tmpdir / 'pack.jl'}"
-    else:
-        command = f"{packmol_executable} < {input_file.name}"
 
-    subprocess.run(
-        command,
-        cwd=tmpdir,
-        shell=True,
-        check=True,
-        capture_output=not verbose,
-    )
+    if packmol_executable == "packmol.jl":
+            subprocess.run(["julia", str(tmpdir / "pack.jl")], cwd=tmpdir, check=True, capture_output=not verbose)
+    else:
+        # e.g., run packmol with stdin to avoid shell redirection
+        with open(input_file, "rb") as fin:
+            subprocess.run([packmol_executable], cwd=tmpdir, check=True, capture_output=not verbose, stdin=fin)
+
 
 
 def _write_molecule_files(
@@ -180,7 +177,7 @@ def pack(
         If True, enables logging of the packing process, by default False.
     packmol : str, optional
         The path to the packmol executable, by default "packmol".
-        When installing packmol via jula, use "packmol.jl".
+        When installing Packmol via Julia, use "packmol.jl".
     pbc : bool, optional
         Ensure tolerance across periodic boundaries, by default True.
     output_format : str, optional

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -7,6 +7,17 @@ from rdkit2ase import ase2rdkit, pack, smiles2conformers
 
 
 @pytest.mark.parametrize("packmol", ["packmol", "packmol.jl"])
+def test_pack_clean_info_arrays(packmol):
+    water = smiles2conformers("O", 1)
+    atoms = pack([water], [10], 997, 42, tolerance=1.5, packmol=packmol)
+    # we don't want to have unused info in the atoms object.
+    assert "atomtypes" not in atoms.arrays
+    assert "bfactor" not in atoms.arrays
+    assert "occupancy" not in atoms.arrays
+    assert "residuenames" not in atoms.arrays
+    assert "residuenumbers" not in atoms.arrays
+
+@pytest.mark.parametrize("packmol", ["packmol", "packmol.jl"])
 def test_pack_pbc(packmol):
     water = smiles2conformers("O", 1)
     mol_dist = water[0].get_all_distances()

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -118,3 +118,18 @@ def test_pack_charges(packmol):
     # check charges
     charges = [atom.GetFormalCharge() for atom in mol.GetAtoms()]
     assert charges == [0, 0, 0, -1, 0, 1] + [1, 0, 0, -1, 0, 0, 0, 0, 0, 0]
+
+
+@pytest.mark.parametrize("packmol", ["packmol", "packmol.jl"])
+def test_pack_ratio(packmol):
+    water = smiles2conformers("O", 1)
+    # pack a cubic box
+    box = pack([water], [10], 1000, 42, tolerance=1.5, packmol=packmol)
+    assert box.cell[0, 0] == pytest.approx(box.cell[1, 1])
+    assert box.cell[1, 1] == pytest.approx(box.cell[2, 2])
+    assert box.get_volume() == pytest.approx(300, rel=1e-2)
+    # pack a rectangular box
+    box = pack([water], [10], 997, 42, ratio=(1, 2, 3), tolerance=1.5, packmol=packmol)
+    assert box.cell[0, 0] * 2 == pytest.approx(box.cell[1, 1])
+    assert box.cell[0, 0] * 3 == pytest.approx(box.cell[2, 2])
+    assert box.get_volume() == pytest.approx(300, rel=1e-2)

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -129,8 +129,11 @@ def test_pack_ratio(packmol):
     assert box.cell[0, 0] == pytest.approx(box.cell[1, 1])
     assert box.cell[1, 1] == pytest.approx(box.cell[2, 2])
     assert box.get_volume() == pytest.approx(300, rel=1e-2)
+    # npt.assert_allclose(box.get_positions(), box.get_positions(wrap=True))
+
     # pack a rectangular box
     box = pack([water], [10], 997, 42, ratio=(1, 2, 3), tolerance=1.5, packmol=packmol)
     assert box.cell[0, 0] * 2 == pytest.approx(box.cell[1, 1])
     assert box.cell[0, 0] * 3 == pytest.approx(box.cell[2, 2])
     assert box.get_volume() == pytest.approx(300, rel=1e-2)
+    # npt.assert_allclose(box.get_positions(), box.get_positions(wrap=True))

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -17,6 +17,7 @@ def test_pack_clean_info_arrays(packmol):
     assert "residuenames" not in atoms.arrays
     assert "residuenumbers" not in atoms.arrays
 
+
 @pytest.mark.parametrize("packmol", ["packmol", "packmol.jl"])
 def test_pack_pbc(packmol):
     water = smiles2conformers("O", 1)


### PR DESCRIPTION
fixes #71 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ratio parameter to control box aspect ratio when packing, preserving total volume.

* **Bug Fixes**
  * Remove unused per-atom fields from packed outputs (atomtypes, bfactor, occupancy, residuenames, residuenumbers).

* **Documentation**
  * Docstring updated to describe the ratio parameter and default cubic behavior.

* **Tests**
  * Added tests validating cleaned per-atom arrays and box scaling/volume preservation across packmol backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->