### PR TITLE
Preserve original_index across all conversion interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #.idea/
 tmp/
 .DS_Store
+
+# Git worktrees
+.worktrees/

--- a/src/molify/ase2x.py
+++ b/src/molify/ase2x.py
@@ -20,13 +20,16 @@ def _create_graph_from_connectivity(
     graph.graph[GraphAttr.PBC] = atoms.pbc
     graph.graph[GraphAttr.CELL] = atoms.cell
 
+    stored_indices = atoms.info.get(NodeAttr.ORIGINAL_INDEX)
+
     for i, atom in enumerate(atoms):
+        original_index = stored_indices[i] if stored_indices is not None else atom.index
         graph.add_node(
             i,
             **{
                 NodeAttr.POSITION: atom.position,
                 NodeAttr.ATOMIC_NUMBER: int(atom.number),
-                NodeAttr.ORIGINAL_INDEX: atom.index,
+                NodeAttr.ORIGINAL_INDEX: original_index,
                 NodeAttr.CHARGE: charges[i],
             },
         )
@@ -89,10 +92,13 @@ def _add_node_properties(
     graph: nx.Graph, atoms: ase.Atoms, charges, non_bonding_atomic_numbers
 ):
     """Add node properties to the graph."""
+    stored_indices = atoms.info.get(NodeAttr.ORIGINAL_INDEX)
+
     for i, atom in enumerate(atoms):
+        original_index = stored_indices[i] if stored_indices is not None else atom.index
         graph.nodes[i][NodeAttr.POSITION] = atom.position
         graph.nodes[i][NodeAttr.ATOMIC_NUMBER] = int(atom.number)
-        graph.nodes[i][NodeAttr.ORIGINAL_INDEX] = atom.index
+        graph.nodes[i][NodeAttr.ORIGINAL_INDEX] = original_index
         graph.nodes[i][NodeAttr.CHARGE] = float(charges[i])
         if atom.number in non_bonding_atomic_numbers:
             graph.nodes[i][NodeAttr.CHARGE] = 1.0

--- a/src/molify/ase2x.py
+++ b/src/molify/ase2x.py
@@ -4,6 +4,8 @@ import numpy as np
 from ase.neighborlist import natural_cutoffs, neighbor_list
 from rdkit import Chem
 
+from molify.constants import EdgeAttr, GraphAttr, NodeAttr
+
 try:
     import vesin
 except ImportError:
@@ -15,20 +17,22 @@ def _create_graph_from_connectivity(
 ) -> nx.Graph:
     """Create NetworkX graph from explicit connectivity information."""
     graph = nx.Graph()
-    graph.graph["pbc"] = atoms.pbc
-    graph.graph["cell"] = atoms.cell
+    graph.graph[GraphAttr.PBC] = atoms.pbc
+    graph.graph[GraphAttr.CELL] = atoms.cell
 
     for i, atom in enumerate(atoms):
         graph.add_node(
             i,
-            position=atom.position,
-            atomic_number=int(atom.number),
-            original_index=atom.index,
-            charge=charges[i],
+            **{
+                NodeAttr.POSITION: atom.position,
+                NodeAttr.ATOMIC_NUMBER: int(atom.number),
+                NodeAttr.ORIGINAL_INDEX: atom.index,
+                NodeAttr.CHARGE: charges[i],
+            },
         )
 
     for i, j, bond_order in connectivity:
-        graph.add_edge(i, j, bond_order=bond_order)
+        graph.add_edge(i, j, **{EdgeAttr.BOND_ORDER: bond_order})
     return graph
 
 
@@ -86,12 +90,12 @@ def _add_node_properties(
 ):
     """Add node properties to the graph."""
     for i, atom in enumerate(atoms):
-        graph.nodes[i]["position"] = atom.position
-        graph.nodes[i]["atomic_number"] = int(atom.number)
-        graph.nodes[i]["original_index"] = atom.index
-        graph.nodes[i]["charge"] = float(charges[i])
+        graph.nodes[i][NodeAttr.POSITION] = atom.position
+        graph.nodes[i][NodeAttr.ATOMIC_NUMBER] = int(atom.number)
+        graph.nodes[i][NodeAttr.ORIGINAL_INDEX] = atom.index
+        graph.nodes[i][NodeAttr.CHARGE] = float(charges[i])
         if atom.number in non_bonding_atomic_numbers:
-            graph.nodes[i]["charge"] = 1.0
+            graph.nodes[i][NodeAttr.CHARGE] = 1.0
 
 
 def ase2networkx(
@@ -158,8 +162,8 @@ def ase2networkx(
         return nx.Graph()
     charges = atoms.get_initial_charges()
 
-    if "connectivity" in atoms.info:
-        connectivity = atoms.info["connectivity"]
+    if GraphAttr.CONNECTIVITY in atoms.info:
+        connectivity = atoms.info[GraphAttr.CONNECTIVITY]
         # ensure connectivity is list[tuple[int, int, float|None]] and
         # does not contain np.generic
         connectivity = [
@@ -174,12 +178,12 @@ def ase2networkx(
 
     graph = nx.from_numpy_array(connectivity_matrix, edge_attr=None)
     for u, v in graph.edges():
-        graph.edges[u, v]["bond_order"] = None
+        graph.edges[u, v][EdgeAttr.BOND_ORDER] = None
 
     _add_node_properties(graph, atoms, charges, non_bonding_atomic_numbers)
 
-    graph.graph["pbc"] = atoms.pbc
-    graph.graph["cell"] = atoms.cell
+    graph.graph[GraphAttr.PBC] = atoms.pbc
+    graph.graph[GraphAttr.CELL] = atoms.cell
 
     return graph
 

--- a/src/molify/compress.py
+++ b/src/molify/compress.py
@@ -2,6 +2,7 @@ import ase
 import numpy as np
 from ase.cell import Cell
 
+from molify.constants import GraphAttr
 from molify.utils import calculate_box_dimensions
 
 
@@ -28,7 +29,7 @@ def compress(
     if freeze_molecules:
         new_cell = Cell.new(new_dimensions)
         old_cell = atoms.get_cell()
-        connectivity = atoms.info.get("connectivity")
+        connectivity = atoms.info.get(GraphAttr.CONNECTIVITY)
         if connectivity is None:
             raise ValueError("No connectivity info found for freeze_molecules=True")
 

--- a/src/molify/constants.py
+++ b/src/molify/constants.py
@@ -1,0 +1,27 @@
+"""String constants used as attribute keys across molify conversions."""
+
+from enum import StrEnum
+
+
+class NodeAttr(StrEnum):
+    """Attribute keys stored on networkx graph nodes."""
+
+    POSITION = "position"
+    ATOMIC_NUMBER = "atomic_number"
+    ORIGINAL_INDEX = "original_index"
+    CHARGE = "charge"
+
+
+class EdgeAttr(StrEnum):
+    """Attribute keys stored on networkx graph edges."""
+
+    BOND_ORDER = "bond_order"
+
+
+class GraphAttr(StrEnum):
+    """Attribute keys stored on networkx graph-level or ASE atoms.info dicts."""
+
+    PBC = "pbc"
+    CELL = "cell"
+    CONNECTIVITY = "connectivity"
+    SMILES = "smiles"

--- a/src/molify/constants.py
+++ b/src/molify/constants.py
@@ -1,6 +1,14 @@
 """String constants used as attribute keys across molify conversions."""
 
-from enum import StrEnum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of StrEnum for Python 3.10."""
 
 
 class NodeAttr(StrEnum):

--- a/src/molify/networkx2x.py
+++ b/src/molify/networkx2x.py
@@ -3,6 +3,7 @@ import networkx as nx
 import numpy as np
 from rdkit import Chem
 
+from molify.constants import EdgeAttr, GraphAttr, NodeAttr
 from molify.utils import bond_type_from_order
 
 
@@ -46,27 +47,33 @@ def networkx2ase(graph: nx.Graph) -> ase.Atoms:
     # Create mapping from original node indices to new sequential indices
     node_mapping = {node: i for i, node in enumerate(graph.nodes)}
 
-    positions = np.array([graph.nodes[n]["position"] for n in graph.nodes])
-    numbers = np.array([graph.nodes[n]["atomic_number"] for n in graph.nodes])
-    charges = np.array([graph.nodes[n]["charge"] for n in graph.nodes])
+    positions = np.array([graph.nodes[n][NodeAttr.POSITION] for n in graph.nodes])
+    numbers = np.array([graph.nodes[n][NodeAttr.ATOMIC_NUMBER] for n in graph.nodes])
+    charges = np.array([graph.nodes[n][NodeAttr.CHARGE] for n in graph.nodes])
 
     atoms = ase.Atoms(
         positions=positions,
         numbers=numbers,
         charges=charges,
-        pbc=graph.graph.get("pbc", False),
-        cell=graph.graph.get("cell", None),
+        pbc=graph.graph.get(GraphAttr.PBC, False),
+        cell=graph.graph.get(GraphAttr.CELL, None),
     )
 
     connectivity = []
     for u, v, data in graph.edges(data=True):
-        bond_order = data["bond_order"]
+        bond_order = data[EdgeAttr.BOND_ORDER]
         # Map original node indices to new sequential indices
         new_u = node_mapping[u]
         new_v = node_mapping[v]
         connectivity.append((new_u, new_v, bond_order))
 
-    atoms.info["connectivity"] = connectivity
+    atoms.info[GraphAttr.CONNECTIVITY] = connectivity
+
+    original_indices = [
+        graph.nodes[n].get(NodeAttr.ORIGINAL_INDEX) for n in graph.nodes
+    ]
+    if all(idx is not None for idx in original_indices):
+        atoms.info[NodeAttr.ORIGINAL_INDEX] = original_indices
 
     return atoms
 
@@ -131,7 +138,7 @@ def networkx2rdkit(graph: nx.Graph, suggestions: list[str] | None = None) -> Che
 
     # Check if any edges have bond_order=None and determine them if needed
     has_none_bond_orders = any(
-        data.get("bond_order") is None for u, v, data in graph.edges(data=True)
+        data.get(EdgeAttr.BOND_ORDER) is None for u, v, data in graph.edges(data=True)
     )
 
     if has_none_bond_orders:
@@ -141,7 +148,7 @@ def networkx2rdkit(graph: nx.Graph, suggestions: list[str] | None = None) -> Che
 
         # Verify all bond orders are now determined
         for u, v, data in graph.edges(data=True):
-            bond_order = data.get("bond_order")
+            bond_order = data.get(EdgeAttr.BOND_ORDER)
             if bond_order is None:
                 raise ValueError(
                     f"Failed to determine bond order for edge ({u}, {v}).\n"
@@ -159,22 +166,29 @@ def networkx2rdkit(graph: nx.Graph, suggestions: list[str] | None = None) -> Che
     nx_to_rdkit_atom_map = {}
 
     for node_id, attributes in graph.nodes(data=True):
-        atomic_number = attributes.get("atomic_number")
-        charge = attributes.get("charge", 0)
+        atomic_number = attributes.get(NodeAttr.ATOMIC_NUMBER)
+        charge = attributes.get(NodeAttr.CHARGE, 0)
 
         if atomic_number is None:
-            raise ValueError(f"Node {node_id} is missing 'atomic_number' attribute.")
+            raise ValueError(
+                f"Node {node_id} is missing '{NodeAttr.ATOMIC_NUMBER}' attribute."
+            )
 
         atom = Chem.Atom(int(atomic_number))
         atom.SetFormalCharge(int(charge))
+        original_index = attributes.get(NodeAttr.ORIGINAL_INDEX)
+        if original_index is not None:
+            atom.SetIntProp(NodeAttr.ORIGINAL_INDEX, int(original_index))
         idx = mol.AddAtom(atom)
         nx_to_rdkit_atom_map[node_id] = idx
 
     for u, v, data in graph.edges(data=True):
-        bond_order = data.get("bond_order")
+        bond_order = data.get(EdgeAttr.BOND_ORDER)
 
         if bond_order is None:
-            raise ValueError(f"Edge ({u}, {v}) is missing 'bond_order' attribute.")
+            raise ValueError(
+                f"Edge ({u}, {v}) is missing '{EdgeAttr.BOND_ORDER}' attribute."
+            )
 
         mol.AddBond(
             nx_to_rdkit_atom_map[u],

--- a/src/molify/pack.py
+++ b/src/molify/pack.py
@@ -9,6 +9,7 @@ import numpy as np
 from ase.io.proteindatabank import write_proteindatabank
 from rdkit import Chem
 
+from molify.constants import GraphAttr
 from molify.utils import calculate_box_dimensions
 
 log = logging.getLogger(__name__)
@@ -125,14 +126,14 @@ def _extract_atom_arrays(
             )
             packed_atoms.arrays[key] = concatenated_array
 
-    if all("connectivity" in atoms.info for atoms in selected_images):
+    if all(GraphAttr.CONNECTIVITY in atoms.info for atoms in selected_images):
         bonds = []
         offset = 0
         for atoms in selected_images:
-            for bond in atoms.info["connectivity"]:
+            for bond in atoms.info[GraphAttr.CONNECTIVITY]:
                 bonds.append((bond[0] + offset, bond[1] + offset, bond[2]))
             offset += len(atoms)
-        packed_atoms.info["connectivity"] = bonds
+        packed_atoms.info[GraphAttr.CONNECTIVITY] = bonds
     charges = np.concatenate([atom.get_initial_charges() for atom in selected_images])
     if any(charge != 0 for charge in charges):
         packed_atoms.set_initial_charges(charges)

--- a/src/molify/rdkit2x.py
+++ b/src/molify/rdkit2x.py
@@ -3,6 +3,8 @@ import networkx as nx
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
+from molify.constants import EdgeAttr, GraphAttr, NodeAttr
+
 
 def rdkit2ase(mol: Chem.Mol, seed: int = 42) -> ase.Atoms:
     """Convert an RDKit molecule to an ASE Atoms object.
@@ -45,16 +47,22 @@ def rdkit2ase(mol: Chem.Mol, seed: int = 42) -> ase.Atoms:
         positions=mol.GetConformer().GetPositions(),
         numbers=[atom.GetAtomicNum() for atom in mol.GetAtoms()],
     )
-    atoms.info["smiles"] = smiles
-    atoms.info["connectivity"] = []
+    atoms.info[GraphAttr.SMILES] = smiles
+    atoms.info[GraphAttr.CONNECTIVITY] = []
     for bond in mol.GetBonds():
         a1 = bond.GetBeginAtomIdx()
         a2 = bond.GetEndAtomIdx()
         order = bond.GetBondTypeAsDouble()
-        atoms.info["connectivity"].append((a1, a2, order))
+        atoms.info[GraphAttr.CONNECTIVITY].append((a1, a2, order))
 
     if any(charge != 0 for charge in charges):
         atoms.set_initial_charges(charges)
+
+    if all(atom.HasProp(NodeAttr.ORIGINAL_INDEX) for atom in mol.GetAtoms()):
+        atoms.info[NodeAttr.ORIGINAL_INDEX] = [
+            atom.GetIntProp(NodeAttr.ORIGINAL_INDEX) for atom in mol.GetAtoms()
+        ]
+
     return atoms
 
 
@@ -100,11 +108,18 @@ def rdkit2networkx(mol: Chem.Mol) -> nx.Graph:
     mol = Chem.AddHs(mol)
     graph = nx.Graph()
     for atom in mol.GetAtoms():
+        original_index = (
+            atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)
+            if atom.HasProp(NodeAttr.ORIGINAL_INDEX)
+            else atom.GetIdx()
+        )
         graph.add_node(
             atom.GetIdx(),
-            atomic_number=atom.GetAtomicNum(),
-            original_index=atom.GetIdx(),
-            charge=atom.GetFormalCharge(),
+            **{
+                NodeAttr.ATOMIC_NUMBER: atom.GetAtomicNum(),
+                NodeAttr.ORIGINAL_INDEX: original_index,
+                NodeAttr.CHARGE: atom.GetFormalCharge(),
+            },
         )
 
     for bond in mol.GetBonds():
@@ -120,6 +135,8 @@ def rdkit2networkx(mol: Chem.Mol) -> nx.Graph:
             bond_order = 1.5
 
         graph.add_edge(
-            bond.GetBeginAtomIdx(), bond.GetEndAtomIdx(), bond_order=bond_order
+            bond.GetBeginAtomIdx(),
+            bond.GetEndAtomIdx(),
+            **{EdgeAttr.BOND_ORDER: bond_order},
         )
     return graph

--- a/src/molify/smiles2x.py
+++ b/src/molify/smiles2x.py
@@ -3,6 +3,8 @@ import numpy as np
 from rdkit import Chem
 from rdkit.Chem import rdDistGeom
 
+from molify.constants import GraphAttr
+
 
 def get_pf6() -> ase.Atoms:
     directions = np.array(
@@ -23,8 +25,8 @@ def get_pf6() -> ase.Atoms:
 
     atoms = ase.Atoms(symbols=symbols, positions=positions)
 
-    atoms.info["connectivity"] = [(0, i, 1.0) for i in range(1, 7)]
-    atoms.info["smiles"] = "F[P-](F)(F)(F)(F)F"
+    atoms.info[GraphAttr.CONNECTIVITY] = [(0, i, 1.0) for i in range(1, 7)]
+    atoms.info[GraphAttr.SMILES] = "F[P-](F)(F)(F)(F)F"
     atoms.set_initial_charges([-1] + [0] * 6)
 
     return atoms
@@ -140,8 +142,8 @@ def smiles2conformers(
             positions=conf.GetPositions(),
             numbers=[atom.GetAtomicNum() for atom in mol.GetAtoms()],
         )
-        atoms.info["smiles"] = smiles
-        atoms.info["connectivity"] = bonds
+        atoms.info[GraphAttr.SMILES] = smiles
+        atoms.info[GraphAttr.CONNECTIVITY] = bonds
         if charges is not None:
             atoms.set_initial_charges(charges)
         images.append(atoms)

--- a/src/molify/substructure.py
+++ b/src/molify/substructure.py
@@ -7,6 +7,7 @@ from rdkit import Chem
 from rdkit.Chem import Draw
 
 from molify.ase2x import ase2rdkit
+from molify.constants import GraphAttr
 from molify.utils import find_connected_components
 
 
@@ -303,9 +304,9 @@ def iter_fragments(atoms: ase.Atoms) -> list[ase.Atoms]:
     >>> len(fragments)
     2
     """
-    if "connectivity" in atoms.info:
+    if GraphAttr.CONNECTIVITY in atoms.info:
         # connectivity is a list of tuples (i, j, bond_type)
-        connectivity = atoms.info["connectivity"]
+        connectivity = atoms.info[GraphAttr.CONNECTIVITY]
         for component in find_connected_components(connectivity):
             yield atoms[list(component)]
     else:

--- a/tests/integration/test_ase2x.py
+++ b/tests/integration/test_ase2x.py
@@ -5,6 +5,7 @@ import pytest
 from rdkit import Chem
 
 import molify
+from molify.constants import GraphAttr, NodeAttr
 
 
 class SMILES:
@@ -343,3 +344,48 @@ def test_ase2networkx_preserves_none_bond_orders_in_connectivity():
     for i, j, bond_order in connectivity_without_orders:
         assert graph.has_edge(i, j)
         assert graph.edges[i, j]["bond_order"] is None
+
+
+class TestAse2NetworkxOriginalIndex:
+    """Test that ase2networkx reads back original_index from atoms.info."""
+
+    def test_reads_stored_original_index_with_connectivity(self):
+        """ase2networkx should use atoms.info['original_index'] when present.
+
+        This tests the _create_graph_from_connectivity path.
+        """
+        atoms = molify.smiles2atoms("CCO")
+        # Manually set non-trivial original_index so the test isn't trivially true
+        atoms.info[NodeAttr.ORIGINAL_INDEX] = list(range(10, 10 + len(atoms)))
+
+        graph = molify.ase2networkx(atoms)
+
+        expected = list(range(10, 10 + len(atoms)))
+        actual = [graph.nodes[n][NodeAttr.ORIGINAL_INDEX] for n in graph.nodes]
+        assert actual == expected
+
+    def test_reads_stored_original_index_without_connectivity(self):
+        """ase2networkx should use atoms.info['original_index'] when present.
+
+        This tests the _add_node_properties path (no connectivity in atoms.info).
+        """
+        atoms = molify.smiles2atoms("CCO")
+        # Store non-trivial original_index, then remove connectivity
+        atoms.info[NodeAttr.ORIGINAL_INDEX] = list(range(10, 10 + len(atoms)))
+        del atoms.info[GraphAttr.CONNECTIVITY]
+
+        graph = molify.ase2networkx(atoms)
+
+        expected = list(range(10, 10 + len(atoms)))
+        actual = [graph.nodes[n][NodeAttr.ORIGINAL_INDEX] for n in graph.nodes]
+        assert actual == expected
+
+    def test_defaults_to_atom_index_without_stored_indices(self):
+        """Without atoms.info['original_index'], use sequential atom.index."""
+        atoms = molify.smiles2atoms("CCO")
+        assert NodeAttr.ORIGINAL_INDEX not in atoms.info
+
+        graph = molify.ase2networkx(atoms)
+
+        for n in graph.nodes:
+            assert graph.nodes[n][NodeAttr.ORIGINAL_INDEX] == n

--- a/tests/integration/test_networkx2x.py
+++ b/tests/integration/test_networkx2x.py
@@ -3,6 +3,7 @@ import pytest
 from rdkit import Chem
 
 import molify
+from molify.constants import EdgeAttr, NodeAttr
 
 
 class SMILES:
@@ -601,3 +602,94 @@ def test_modify_graph_combined_add_remove_to_rdkit():
     assert 9 in atom_nums  # Fluorine should be present
     assert 6 in atom_nums  # Carbon should be present
     assert 8 in atom_nums  # Oxygen should be present
+
+
+# ============================================================================
+# Tests for original_index preservation (GitHub issue #104)
+# ============================================================================
+
+
+class TestNetworkx2RdkitOriginalIndex:
+    """Test that networkx2rdkit preserves original_index from graph nodes."""
+
+    def test_original_index_stored_on_rdkit_atoms(self):
+        """original_index should be an RDKit atom int property."""
+        atoms = molify.smiles2atoms("CCO")
+        graph = molify.ase2networkx(atoms)
+
+        mol = molify.networkx2rdkit(graph)
+
+        for i, (node_id, attributes) in enumerate(graph.nodes(data=True)):
+            rdkit_atom = mol.GetAtomWithIdx(i)
+            assert rdkit_atom.HasProp(NodeAttr.ORIGINAL_INDEX)
+            assert (
+                rdkit_atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)
+                == attributes[NodeAttr.ORIGINAL_INDEX]
+            )
+
+    def test_original_index_preserved_with_subgraph(self):
+        """original_index should be preserved even with non-sequential node IDs."""
+        atoms = molify.smiles2atoms("CCO")
+        graph = molify.ase2networkx(atoms)
+
+        heavy_atom_nodes = [
+            n for n, d in graph.nodes(data=True) if d[NodeAttr.ATOMIC_NUMBER] != 1
+        ]
+        subgraph = graph.subgraph(heavy_atom_nodes).copy()
+
+        mol = molify.networkx2rdkit(subgraph)
+
+        for i, (node_id, attributes) in enumerate(subgraph.nodes(data=True)):
+            rdkit_atom = mol.GetAtomWithIdx(i)
+            assert (
+                rdkit_atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)
+                == attributes[NodeAttr.ORIGINAL_INDEX]
+            )
+
+    def test_original_index_preserved_with_none_bond_orders(self):
+        """original_index preserved with auto bond orders."""
+        atoms = molify.smiles2atoms("CC")
+        graph = molify.ase2networkx(atoms)
+
+        for u, v in graph.edges():
+            graph.edges[u, v][EdgeAttr.BOND_ORDER] = None
+
+        mol = molify.networkx2rdkit(graph, suggestions=[])
+
+        for i, (node_id, attributes) in enumerate(graph.nodes(data=True)):
+            rdkit_atom = mol.GetAtomWithIdx(i)
+            assert (
+                rdkit_atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)
+                == attributes[NodeAttr.ORIGINAL_INDEX]
+            )
+
+
+class TestNetworkx2AseOriginalIndex:
+    """Test that networkx2ase preserves original_index from graph nodes."""
+
+    def test_original_index_stored_in_atoms_info(self):
+        """original_index from networkx nodes should be stored in atoms.info."""
+        atoms = molify.smiles2atoms("CCO")
+        graph = molify.ase2networkx(atoms)
+
+        new_atoms = molify.networkx2ase(graph)
+
+        assert NodeAttr.ORIGINAL_INDEX in new_atoms.info
+        expected = [graph.nodes[n][NodeAttr.ORIGINAL_INDEX] for n in graph.nodes]
+        assert new_atoms.info[NodeAttr.ORIGINAL_INDEX] == expected
+
+    def test_original_index_preserved_with_subgraph(self):
+        """original_index should reflect original atom indices, not remapped ones."""
+        atoms = molify.smiles2atoms("CCO")
+        graph = molify.ase2networkx(atoms)
+
+        heavy_atom_nodes = [
+            n for n, d in graph.nodes(data=True) if d[NodeAttr.ATOMIC_NUMBER] != 1
+        ]
+        subgraph = graph.subgraph(heavy_atom_nodes).copy()
+
+        new_atoms = molify.networkx2ase(subgraph)
+
+        assert NodeAttr.ORIGINAL_INDEX in new_atoms.info
+        expected = [subgraph.nodes[n][NodeAttr.ORIGINAL_INDEX] for n in subgraph.nodes]
+        assert new_atoms.info[NodeAttr.ORIGINAL_INDEX] == expected

--- a/tests/integration/test_networkx2x.py
+++ b/tests/integration/test_networkx2x.py
@@ -619,7 +619,7 @@ class TestNetworkx2RdkitOriginalIndex:
 
         mol = molify.networkx2rdkit(graph)
 
-        for i, (node_id, attributes) in enumerate(graph.nodes(data=True)):
+        for i, (_node_id, attributes) in enumerate(graph.nodes(data=True)):
             rdkit_atom = mol.GetAtomWithIdx(i)
             assert rdkit_atom.HasProp(NodeAttr.ORIGINAL_INDEX)
             assert (
@@ -639,7 +639,7 @@ class TestNetworkx2RdkitOriginalIndex:
 
         mol = molify.networkx2rdkit(subgraph)
 
-        for i, (node_id, attributes) in enumerate(subgraph.nodes(data=True)):
+        for i, (_node_id, attributes) in enumerate(subgraph.nodes(data=True)):
             rdkit_atom = mol.GetAtomWithIdx(i)
             assert (
                 rdkit_atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)
@@ -656,7 +656,7 @@ class TestNetworkx2RdkitOriginalIndex:
 
         mol = molify.networkx2rdkit(graph, suggestions=[])
 
-        for i, (node_id, attributes) in enumerate(graph.nodes(data=True)):
+        for i, (_node_id, attributes) in enumerate(graph.nodes(data=True)):
             rdkit_atom = mol.GetAtomWithIdx(i)
             assert (
                 rdkit_atom.GetIntProp(NodeAttr.ORIGINAL_INDEX)

--- a/tests/test_rdkit2ase.py
+++ b/tests/test_rdkit2ase.py
@@ -5,7 +5,8 @@ import pytest
 import rdkit
 from rdkit import Chem
 
-from molify import ase2rdkit, rdkit2ase, smiles2atoms
+from molify import ase2rdkit, rdkit2ase, rdkit2networkx, smiles2atoms
+from molify.constants import NodeAttr
 
 
 @pytest.fixture
@@ -147,3 +148,58 @@ def test_rdkit2ase_nacn():
     ]
     assert atoms.get_initial_charges().tolist() == [-1, 0, 1]
     assert atoms.get_atomic_numbers().tolist() == [6, 7, 11]
+
+
+# ============================================================================
+# Tests for original_index preservation (GitHub issue #104)
+# ============================================================================
+
+
+class TestRdkit2AseOriginalIndex:
+    """Test that rdkit2ase preserves original_index from RDKit atom properties."""
+
+    def test_original_index_carried_from_rdkit_to_ase(self):
+        """If RDKit atoms have original_index, store it."""
+        mol = Chem.RWMol(Chem.MolFromSmiles("CO"))
+        mol = Chem.AddHs(mol)
+        # Set original_index on each atom (simulating a prior networkx2rdkit conversion)
+        for atom in mol.GetAtoms():
+            atom.SetIntProp(NodeAttr.ORIGINAL_INDEX, atom.GetIdx() + 10)
+
+        atoms = rdkit2ase(mol)
+
+        assert NodeAttr.ORIGINAL_INDEX in atoms.info
+        expected = [atom.GetIdx() + 10 for atom in mol.GetAtoms()]
+        assert atoms.info[NodeAttr.ORIGINAL_INDEX] == expected
+
+    def test_no_original_index_when_rdkit_atoms_lack_property(self):
+        """No original_index added when absent from RDKit atoms."""
+        mol = Chem.MolFromSmiles("CO")
+        atoms = rdkit2ase(mol)
+
+        assert NodeAttr.ORIGINAL_INDEX not in atoms.info
+
+
+class TestRdkit2NetworkxOriginalIndex:
+    """Test that rdkit2networkx preserves original_index from RDKit atom properties."""
+
+    def test_original_index_carried_from_rdkit_to_networkx(self):
+        """If RDKit atoms have original_index, use it."""
+        mol = Chem.RWMol(Chem.MolFromSmiles("CO"))
+        mol = Chem.AddHs(mol)
+        for atom in mol.GetAtoms():
+            atom.SetIntProp(NodeAttr.ORIGINAL_INDEX, atom.GetIdx() + 20)
+
+        graph = rdkit2networkx(mol)
+
+        for node_id, attributes in graph.nodes(data=True):
+            assert attributes[NodeAttr.ORIGINAL_INDEX] == node_id + 20
+
+    def test_falls_back_to_getidx_without_property(self):
+        """Falls back to GetIdx() without original_index."""
+        mol = Chem.MolFromSmiles("CO")
+
+        graph = rdkit2networkx(mol)
+
+        for node_id, attributes in graph.nodes(data=True):
+            assert attributes[NodeAttr.ORIGINAL_INDEX] == node_id


### PR DESCRIPTION
## Summary
- Fixes #104: `original_index` is now preserved across all nx/rdkit/ase conversions
- `networkx2rdkit`: stores `original_index` as an RDKit atom int property
- `networkx2ase`: stores `original_index` list in `atoms.info`
- `rdkit2ase`: carries `original_index` from RDKit atom properties to `atoms.info`
- `rdkit2networkx`: reads `original_index` from RDKit atom property when available, falls back to `GetIdx()`
- Introduces `molify.constants` module with `StrEnum` keys (`NodeAttr`, `EdgeAttr`, `GraphAttr`) replacing magic strings

## Test plan
- [x] 9 new tests covering all 4 conversion functions (sequential, subgraph, auto bond orders, fallback behavior)
- [x] Full suite: 450 tests pass, zero regressions
- [x] Pre-commit (ruff lint + format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Molecule conversions now support preservation and propagation of original atom indices when converting between ASE, NetworkX, and RDKit formats.

* **Refactor**
  * Standardized internal attribute key management across molecule conversion modules.

* **Tests**
  * Added comprehensive test coverage for original index propagation across supported molecule format conversions.

* **Chores**
  * Updated `.gitignore` to exclude Git worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->