### PR TITLE
build: switch to hatch-vcs for automatic git-tag versioning

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -5,21 +5,38 @@ on:
   release:
     types:
       - published
+
 jobs:
-  pypi-publish:
-    name: Upload release to PyPI
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  upload_pypi:
+    needs: [build]
     environment:
       name: pypi
       url: https://pypi.org/p/molify
     permissions:
       id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'published')
     steps:
-    - uses: actions/checkout@v5
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    - name: Build
-      run: |
-          uv build
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #.idea/
 tmp/
 .DS_Store
+
+# hatch-vcs generated version file
+src/molify/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "molify"
-version = "0.2.2"
+dynamic = ["version"]
 description = "Molecular Structure Interface with RDKit, ASE, Packmol and NetworkX"
 readme = "README.md"
 license = "Apache-2.0"
@@ -52,8 +52,14 @@ extend-ignore = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/molify/_version.py"
 
 [tool.codespell]
 ignore-words-list = "basf"

--- a/uv.lock
+++ b/uv.lock
@@ -1231,7 +1231,6 @@ wheels = [
 
 [[package]]
 name = "molify"
-version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },


### PR DESCRIPTION
## Summary
- Replace static `version = "0.2.2"` with dynamic versioning via `hatch-vcs` (git tags)
- Add `[tool.hatch.version]` and `[tool.hatch.build.hooks.vcs]` config to `pyproject.toml`
- Update publish workflow with separate build/upload jobs and `fetch-depth: 0` for full git history
- Add generated `src/molify/_version.py` to `.gitignore`

Same build system as zincware/asebytes#15.

## Test plan
- [x] `uv build` produces correctly versioned wheel and sdist
- [x] All 439 tests pass
- [x] `_version.py` is generated and gitignored
- [ ] Verify PyPI publish workflow on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)