### PR TITLE
Propagate atom tags from selected image to packed box

### DIFF
--- a/src/molify/pack.py
+++ b/src/molify/pack.py
@@ -137,6 +137,9 @@ def _extract_atom_arrays(
     charges = np.concatenate([atom.get_initial_charges() for atom in selected_images])
     if any(charge != 0 for charge in charges):
         packed_atoms.set_initial_charges(charges)
+    tags = np.concatenate([atom.get_tags() for atom in selected_images])
+    if any(tag != 0 for tag in tags):
+        packed_atoms.set_tags(tags)
     return packed_atoms
 
 

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -109,6 +109,18 @@ def test_pack_charges():
     assert charges == [0, 0, 0, -1, 0, 1] + [1, 0, 0, -1, 0, 0, 0, 0, 0, 0]
 
 
+def test_pack_tags():
+    water = smiles2conformers("O", 1)
+    methane = smiles2conformers("C", 1)
+    water[0].set_tags(range(1, 4))  # O, H, H -> 1, 2, 3
+    methane[0].set_tags(range(4, 9))  # C, H, H, H, H -> 4, 5, 6, 7, 8
+
+    atoms = pack([water, methane], [2, 1], density=1000)
+    npt.assert_array_equal(
+        atoms.get_tags(), [1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8]
+    )
+
+
 def test_pack_ratio():
     water = smiles2conformers("O", 1)
     # pack a cubic box

--- a/tests/test_solvate.py
+++ b/tests/test_solvate.py
@@ -116,9 +116,7 @@ def test_pack_tags():
     methane[0].set_tags(range(4, 9))  # C, H, H, H, H -> 4, 5, 6, 7, 8
 
     atoms = pack([water, methane], [2, 1], density=1000)
-    npt.assert_array_equal(
-        atoms.get_tags(), [1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8]
-    )
+    npt.assert_array_equal(atoms.get_tags(), [1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8])
 
 
 def test_pack_ratio():


### PR DESCRIPTION
Resolves #118: Add logic to propagate atom tags from selected conformer images to packed box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Atom tags are now preserved when packing multiple molecules, ensuring per-atom tag values remain intact and in order in the packed structure.

* **Tests**
  * Added a unit test verifying tagged conformers retain their per-atom tags after packing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zincware/molify/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->