### PR TITLE
fix: correct compress() density docstring to kg/m³

### DIFF
--- a/src/molify/compress.py
+++ b/src/molify/compress.py
@@ -18,7 +18,7 @@ def compress(
     atoms : ase.Atoms
         The Atoms object to compress.
     density : float
-        The target density in g/cm^3.
+        The target density in kg/m^3.
     freeze_molecules : bool
         If True, freeze the internal degrees of freedom of the molecules
         during compression, to prevent bond compression.


### PR DESCRIPTION
## Summary

`molify.compress`'s docstring documented its `density` argument as **g/cm³**, but the function passes that value straight to `calculate_box_dimensions`, which expects **kg/m³** — the same convention already used by `pack` and `calculate_density`. A user trusting the docstring would pass `1.0` for water (1 g/cm³) and get a box **1000× too sparse**.

The runtime logic was already correct and consistent with the rest of the package; only the docstring was wrong. This standardizes `compress` on the package-wide **kg/m³** convention by fixing the one misleading line.

```diff
     density : float
-        The target density in g/cm^3.
+        The target density in kg/m^3.
```

## Verification (TDD)

The existing `test_compress` / `test_compress_freeze` already pin the kg/m³ contract. To confirm they genuinely guard it, I temporarily applied the naive `density * 1000` "fix":

- **RED:** both tests fail (`calculate_density` → ~1,000,000 instead of 1000).
- **GREEN:** with the unmodified (correct) logic, all **454 tests pass**.

This demonstrates the kg/m³ contract is real and tested, so the docstring correction now matches verified behavior.

## Test Plan

- [x] `uv run pytest` → 454 passed
- [x] Confirmed the rejected `×1000` conversion breaks the suite (RED), proving the contract is guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented density units for compression to use **kg/m³** instead of **g/cm³**.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->