### PR TITLE
feat: add molify command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,18 @@ print(atoms)
 
 ## Command Line Interface
 
-Every command mirrors the molify function of the same name. Structures go to
-standard output as [extxyz](https://github.com/libAtoms/extxyz), which carries
-the cell alongside the SMILES string and the connectivity.
+Every command mirrors the molify function of the same name and writes the
+structure to standard output, ready to redirect or pipe. The default
+[extxyz](https://github.com/libAtoms/extxyz) format carries the cell alongside
+the SMILES string and the connectivity.
 
 ```bash
-molify smiles2atoms CCO --format XYZ > etoh.xyz
-molify smiles2atoms CCO --output etoh.pdb
+molify smiles2atoms CCO > etoh.xyz
+molify smiles2atoms CCO --format PDB | grep ATOM
 ```
 
-The `--format` option takes any ASE format name or file extension, and
-`--output` takes the format from the file suffix.
+The `--format` option takes any ASE format name or file extension, so `XYZ`
+selects the extxyz writer.
 
 ## Packmol Interface
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ print(atoms)
 >>> Atoms(symbols='OH2', pbc=False)
 ```
 
+## Command Line Interface
+
+Every command mirrors the molify function of the same name. Structures go to
+standard output as [extxyz](https://github.com/libAtoms/extxyz), which carries
+the cell alongside the SMILES string and the connectivity.
+
+```bash
+molify smiles2atoms CCO --format XYZ > etoh.xyz
+molify smiles2atoms CCO --output etoh.pdb
+```
+
+The `--format` option takes any ASE format name or file extension, and
+`--output` takes the format from the file suffix.
+
 ## Packmol Interface
 
 Given the molecular units, you can build periodic boxes with a given density

--- a/README.md
+++ b/README.md
@@ -39,18 +39,12 @@ print(atoms)
 
 ## Command Line Interface
 
-Every command mirrors the molify function of the same name and writes the
-structure to standard output, ready to redirect or pipe. The default
-[extxyz](https://github.com/libAtoms/extxyz) format carries the cell alongside
-the SMILES string and the connectivity.
+Commands mirror the molify functions and write to standard output. `--format`
+takes any ASE format name or extension, defaulting to extxyz.
 
 ```bash
 molify smiles2atoms CCO > etoh.xyz
-molify smiles2atoms CCO --format PDB | grep ATOM
 ```
-
-The `--format` option takes any ASE format name or file extension, so `XYZ`
-selects the extxyz writer.
 
 ## Packmol Interface
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,20 @@ The networkx.Graph representation can be obtained from either RDKit or ASE objec
    nh3_graph = molify.ase2networkx(nh3_atoms)
 
 
+**Command Line Interface**
+
+Installing molify provides the ``molify`` command, where every subcommand mirrors
+the molify function of the same name. Structures go to standard output as extxyz,
+which carries the cell alongside the SMILES string and the connectivity.
+
+.. code-block:: console
+
+   $ molify smiles2atoms CCO --format XYZ > etoh.xyz
+   $ molify smiles2atoms CCO --output etoh.pdb
+
+The ``--format`` option takes any ASE format name or file extension, and
+``--output`` takes the format from the file suffix.
+
 Advanced Features
 -----------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,16 +103,17 @@ The networkx.Graph representation can be obtained from either RDKit or ASE objec
 **Command Line Interface**
 
 Installing molify provides the ``molify`` command, where every subcommand mirrors
-the molify function of the same name. Structures go to standard output as extxyz,
-which carries the cell alongside the SMILES string and the connectivity.
+the molify function of the same name and writes the structure to standard output,
+ready to redirect or pipe. The default extxyz format carries the cell alongside
+the SMILES string and the connectivity.
 
 .. code-block:: console
 
-   $ molify smiles2atoms CCO --format XYZ > etoh.xyz
-   $ molify smiles2atoms CCO --output etoh.pdb
+   $ molify smiles2atoms CCO > etoh.xyz
+   $ molify smiles2atoms CCO --format PDB | grep ATOM
 
-The ``--format`` option takes any ASE format name or file extension, and
-``--output`` takes the format from the file suffix.
+The ``--format`` option takes any ASE format name or file extension, so ``XYZ``
+selects the extxyz writer.
 
 Advanced Features
 -----------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -102,18 +102,12 @@ The networkx.Graph representation can be obtained from either RDKit or ASE objec
 
 **Command Line Interface**
 
-Installing molify provides the ``molify`` command, where every subcommand mirrors
-the molify function of the same name and writes the structure to standard output,
-ready to redirect or pipe. The default extxyz format carries the cell alongside
-the SMILES string and the connectivity.
+Commands mirror the molify functions and write to standard output. ``--format``
+takes any ASE format name or extension, defaulting to extxyz.
 
 .. code-block:: console
 
    $ molify smiles2atoms CCO > etoh.xyz
-   $ molify smiles2atoms CCO --format PDB | grep ATOM
-
-The ``--format`` option takes any ASE format name or file extension, so ``XYZ``
-selects the extxyz writer.
 
 Advanced Features
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "networkx>=3.4.2",
     "packmol>=21.1.2",
     "rdkit>=2024",
+    "typer>=0.27.1",
 ]
 
 [dependency-groups]
@@ -31,6 +32,9 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinxcontrib-mermaid>=1.0.0",
 ]
+
+[project.scripts]
+molify = "molify.cli:app"
 
 [project.optional-dependencies]
 

--- a/src/molify/__main__.py
+++ b/src/molify/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m molify``."""
+
+from molify.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/src/molify/cli.py
+++ b/src/molify/cli.py
@@ -7,7 +7,6 @@ from typing import Annotated
 import ase.io
 import typer
 from ase.io.formats import extension2format
-from rdkit import Chem
 
 from molify import __version__
 from molify import smiles2atoms as _smiles2atoms
@@ -41,29 +40,6 @@ def _resolve_format(value: str) -> str:
     return fmt.name if fmt is not None else key
 
 
-def _validate_smiles(value: str) -> str:
-    """Confirm that RDKit parses the given SMILES string.
-
-    Parameters
-    ----------
-    value : str
-        The SMILES string to validate.
-
-    Returns
-    -------
-    str
-        The validated SMILES string.
-
-    Raises
-    ------
-    typer.BadParameter
-        If RDKit rejects the SMILES string.
-    """
-    if Chem.MolFromSmiles(value) is None:
-        raise typer.BadParameter(f"RDKit reads valid SMILES, and rejected {value!r}")
-    return value
-
-
 def _version(value: bool) -> None:
     """Print the molify version and exit."""
     if value:
@@ -93,11 +69,7 @@ def main(
 @app.command()
 def smiles2atoms(
     smiles: Annotated[
-        str,
-        typer.Argument(
-            callback=_validate_smiles,
-            help="SMILES string of the molecule, such as 'CCO'.",
-        ),
+        str, typer.Argument(help="SMILES string of the molecule, such as 'CCO'.")
     ],
     fmt: Annotated[
         str,

--- a/src/molify/cli.py
+++ b/src/molify/cli.py
@@ -1,0 +1,158 @@
+"""Command line interface for molify."""
+
+import pathlib
+from typing import Annotated, Optional
+
+import ase
+import ase.io
+import typer
+from ase.io.formats import extension2format
+from rdkit import Chem
+
+from molify import __version__
+from molify import smiles2atoms as _smiles2atoms
+
+STDOUT_FORMAT = "extxyz"
+
+app = typer.Typer(
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_show_locals=False,
+)
+
+
+def _resolve_format(value: str) -> str:
+    """Map a format name or file extension onto an ASE format name.
+
+    Extensions resolve first, so ``XYZ`` selects ASE's ``extxyz`` writer, which
+    keeps the cell and the ``atoms.info`` payload such as the SMILES string and
+    the connectivity.
+
+    Parameters
+    ----------
+    value : str
+        Format name or file extension, in any capitalisation.
+
+    Returns
+    -------
+    str
+        The format name passed on to :func:`ase.io.write`.
+    """
+    key = value.strip().lower()
+    fmt = extension2format.get(key)
+    return fmt.name if fmt is not None else key
+
+
+def _write(
+    images: ase.Atoms | list[ase.Atoms],
+    fmt: Optional[str],
+    output: Optional[pathlib.Path],
+) -> None:
+    """Write structures to a file, or to standard output.
+
+    Parameters
+    ----------
+    images : ase.Atoms or list of ase.Atoms
+        The structures to write.
+    fmt : str or None
+        An ASE format name. ``None`` takes the format from the ``output``
+        suffix, and ``extxyz`` on standard output.
+    output : pathlib.Path or None
+        Target file. ``None`` writes to standard output.
+    """
+    if output is None:
+        ase.io.write("-", images, format=fmt or STDOUT_FORMAT)
+    elif fmt is None:
+        ase.io.write(output, images)
+    else:
+        ase.io.write(output, images, format=fmt)
+
+
+def _validate_smiles(value: str) -> str:
+    """Confirm that RDKit parses the given SMILES string.
+
+    Parameters
+    ----------
+    value : str
+        The SMILES string to validate.
+
+    Returns
+    -------
+    str
+        The validated SMILES string.
+
+    Raises
+    ------
+    typer.BadParameter
+        If RDKit rejects the SMILES string.
+    """
+    if Chem.MolFromSmiles(value) is None:
+        raise typer.BadParameter(f"RDKit reads valid SMILES, and rejected {value!r}")
+    return value
+
+
+def _version(value: bool) -> None:
+    """Print the molify version and exit."""
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            callback=_version,
+            is_eager=True,
+            help="Show the molify version and exit.",
+        ),
+    ] = False,
+) -> None:
+    """Build molecular structures from the command line.
+
+    Each command mirrors the molify function of the same name.
+    """
+
+
+@app.command()
+def smiles2atoms(
+    smiles: Annotated[
+        str,
+        typer.Argument(
+            callback=_validate_smiles,
+            help="SMILES string of the molecule, such as 'CCO'.",
+        ),
+    ],
+    fmt: Annotated[
+        Optional[str],
+        typer.Option(
+            "--format",
+            "-f",
+            help=(
+                "Output format, given as an ASE format name or file extension."
+                " 'XYZ' selects extxyz, which keeps the SMILES string and the"
+                " connectivity. Taken from the --output suffix when omitted,"
+                " and 'extxyz' on standard output."
+            ),
+        ),
+    ] = None,
+    output: Annotated[
+        Optional[pathlib.Path],
+        typer.Option(
+            "--output",
+            "-o",
+            help="Write to this file. Standard output when omitted.",
+        ),
+    ] = None,
+    seed: Annotated[
+        int, typer.Option(help="Random seed for conformer generation.")
+    ] = 42,
+) -> None:
+    """Convert a SMILES string into a single 3D structure.
+
+    Example: molify smiles2atoms CCO --format XYZ > etoh.xyz
+    """
+    atoms = _smiles2atoms(smiles, seed=seed)
+    _write(atoms, _resolve_format(fmt) if fmt else None, output)

--- a/src/molify/cli.py
+++ b/src/molify/cli.py
@@ -1,9 +1,9 @@
 """Command line interface for molify."""
 
-import pathlib
-from typing import Annotated, Optional
+import io
+import sys
+from typing import Annotated
 
-import ase
 import ase.io
 import typer
 from ase.io.formats import extension2format
@@ -11,8 +11,6 @@ from rdkit import Chem
 
 from molify import __version__
 from molify import smiles2atoms as _smiles2atoms
-
-STDOUT_FORMAT = "extxyz"
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -41,31 +39,6 @@ def _resolve_format(value: str) -> str:
     key = value.strip().lower()
     fmt = extension2format.get(key)
     return fmt.name if fmt is not None else key
-
-
-def _write(
-    images: ase.Atoms | list[ase.Atoms],
-    fmt: Optional[str],
-    output: Optional[pathlib.Path],
-) -> None:
-    """Write structures to a file, or to standard output.
-
-    Parameters
-    ----------
-    images : ase.Atoms or list of ase.Atoms
-        The structures to write.
-    fmt : str or None
-        An ASE format name. ``None`` takes the format from the ``output``
-        suffix, and ``extxyz`` on standard output.
-    output : pathlib.Path or None
-        Target file. ``None`` writes to standard output.
-    """
-    if output is None:
-        ase.io.write("-", images, format=fmt or STDOUT_FORMAT)
-    elif fmt is None:
-        ase.io.write(output, images)
-    else:
-        ase.io.write(output, images, format=fmt)
 
 
 def _validate_smiles(value: str) -> str:
@@ -112,7 +85,8 @@ def main(
 ) -> None:
     """Build molecular structures from the command line.
 
-    Each command mirrors the molify function of the same name.
+    Each command mirrors the molify function of the same name and writes the
+    structure to standard output.
     """
 
 
@@ -126,33 +100,26 @@ def smiles2atoms(
         ),
     ],
     fmt: Annotated[
-        Optional[str],
+        str,
         typer.Option(
             "--format",
             "-f",
             help=(
                 "Output format, given as an ASE format name or file extension."
                 " 'XYZ' selects extxyz, which keeps the SMILES string and the"
-                " connectivity. Taken from the --output suffix when omitted,"
-                " and 'extxyz' on standard output."
+                " connectivity."
             ),
         ),
-    ] = None,
-    output: Annotated[
-        Optional[pathlib.Path],
-        typer.Option(
-            "--output",
-            "-o",
-            help="Write to this file. Standard output when omitted.",
-        ),
-    ] = None,
+    ] = "extxyz",
     seed: Annotated[
         int, typer.Option(help="Random seed for conformer generation.")
     ] = 42,
 ) -> None:
-    """Convert a SMILES string into a single 3D structure.
+    """Convert a SMILES string into a single 3D structure on standard output.
 
     Example: molify smiles2atoms CCO --format XYZ > etoh.xyz
     """
     atoms = _smiles2atoms(smiles, seed=seed)
-    _write(atoms, _resolve_format(fmt) if fmt else None, output)
+    with io.StringIO() as handle:
+        ase.io.write(handle, atoms, format=_resolve_format(fmt))
+        sys.stdout.write(handle.getvalue())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import io
+
 import ase.io
 import pytest
 from typer.testing import CliRunner
@@ -6,6 +8,11 @@ from molify import __version__
 from molify.cli import app
 
 runner = CliRunner()
+
+
+def read_output(result) -> ase.Atoms:
+    """Read the structure the CLI wrote to standard output."""
+    return ase.io.read(io.StringIO(result.output), format="extxyz")
 
 
 def test_version():
@@ -20,59 +27,40 @@ def test_no_args_shows_help():
 
 
 @pytest.mark.parametrize("fmt", ["XYZ", "xyz", "extxyz"])
-def test_smiles2atoms_stdout(fmt):
+def test_smiles2atoms_format_aliases(fmt):
     result = runner.invoke(app, ["smiles2atoms", "CCO", "--format", fmt])
     assert result.exit_code == 0
+
     lines = result.output.strip().split("\n")
     assert lines[0] == "9"
     assert "smiles=CCO" in lines[1]
     assert "connectivity=" in lines[1]
 
 
-def test_smiles2atoms_stdout_defaults_to_extxyz():
+def test_smiles2atoms_defaults_to_extxyz():
     result = runner.invoke(app, ["smiles2atoms", "CCO"])
     assert result.exit_code == 0
-    assert "smiles=CCO" in result.output
 
-
-def test_smiles2atoms_output_file(tmp_path):
-    path = tmp_path / "etoh.xyz"
-    result = runner.invoke(app, ["smiles2atoms", "CCO", "--output", str(path)])
-    assert result.exit_code == 0
-
-    atoms = ase.io.read(path)
+    atoms = read_output(result)
     assert atoms.get_chemical_formula() == "C2H6O"
     assert atoms.info["smiles"] == "CCO"
     assert len(atoms.info["connectivity"]) == 8
 
 
-def test_smiles2atoms_format_from_suffix(tmp_path):
-    path = tmp_path / "etoh.pdb"
-    result = runner.invoke(app, ["smiles2atoms", "CCO", "-o", str(path)])
+def test_smiles2atoms_pdb():
+    result = runner.invoke(app, ["smiles2atoms", "CCO", "-f", "pdb"])
     assert result.exit_code == 0
-    assert path.read_text().startswith("MODEL")
-    assert ase.io.read(path).get_chemical_formula() == "C2H6O"
+    assert result.output.startswith("MODEL")
+    assert ase.io.read(io.StringIO(result.output), format="proteindatabank")
 
 
-def test_smiles2atoms_format_overrides_suffix(tmp_path):
-    path = tmp_path / "etoh.xyz"
-    result = runner.invoke(
-        app, ["smiles2atoms", "CCO", "-o", str(path), "-f", "proteindatabank"]
-    )
-    assert result.exit_code == 0
-    assert path.read_text().startswith("MODEL")
-
-
-def test_smiles2atoms_seed_changes_positions(tmp_path):
-    positions = []
-    for seed in (42, 1234):
-        path = tmp_path / f"conf_{seed}.xyz"
-        result = runner.invoke(
-            app, ["smiles2atoms", "CCO", "-o", str(path), "--seed", str(seed)]
-        )
-        assert result.exit_code == 0
-        positions.append(ase.io.read(path).get_positions())
-
+def test_smiles2atoms_seed_changes_positions():
+    positions = [
+        read_output(
+            runner.invoke(app, ["smiles2atoms", "CCO", "--seed", str(seed)])
+        ).get_positions()
+        for seed in (42, 1234)
+    ]
     assert not (positions[0] == positions[1]).all()
 
 
@@ -82,8 +70,7 @@ def test_smiles2atoms_invalid_smiles():
     assert "C(C" in result.output
 
 
-def test_smiles2atoms_unknown_format(tmp_path):
-    result = runner.invoke(
-        app, ["smiles2atoms", "CCO", "-o", str(tmp_path / "etoh.zzz")]
-    )
+@pytest.mark.parametrize("fmt", ["zzz", "cif"])
+def test_smiles2atoms_ase_rejects_format(fmt):
+    result = runner.invoke(app, ["smiles2atoms", "CCO", "-f", fmt])
     assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,89 @@
+import ase.io
+import pytest
+from typer.testing import CliRunner
+
+from molify import __version__
+from molify.cli import app
+
+runner = CliRunner()
+
+
+def test_version():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == __version__
+
+
+def test_no_args_shows_help():
+    result = runner.invoke(app, [])
+    assert "smiles2atoms" in result.output
+
+
+@pytest.mark.parametrize("fmt", ["XYZ", "xyz", "extxyz"])
+def test_smiles2atoms_stdout(fmt):
+    result = runner.invoke(app, ["smiles2atoms", "CCO", "--format", fmt])
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "9"
+    assert "smiles=CCO" in lines[1]
+    assert "connectivity=" in lines[1]
+
+
+def test_smiles2atoms_stdout_defaults_to_extxyz():
+    result = runner.invoke(app, ["smiles2atoms", "CCO"])
+    assert result.exit_code == 0
+    assert "smiles=CCO" in result.output
+
+
+def test_smiles2atoms_output_file(tmp_path):
+    path = tmp_path / "etoh.xyz"
+    result = runner.invoke(app, ["smiles2atoms", "CCO", "--output", str(path)])
+    assert result.exit_code == 0
+
+    atoms = ase.io.read(path)
+    assert atoms.get_chemical_formula() == "C2H6O"
+    assert atoms.info["smiles"] == "CCO"
+    assert len(atoms.info["connectivity"]) == 8
+
+
+def test_smiles2atoms_format_from_suffix(tmp_path):
+    path = tmp_path / "etoh.pdb"
+    result = runner.invoke(app, ["smiles2atoms", "CCO", "-o", str(path)])
+    assert result.exit_code == 0
+    assert path.read_text().startswith("MODEL")
+    assert ase.io.read(path).get_chemical_formula() == "C2H6O"
+
+
+def test_smiles2atoms_format_overrides_suffix(tmp_path):
+    path = tmp_path / "etoh.xyz"
+    result = runner.invoke(
+        app, ["smiles2atoms", "CCO", "-o", str(path), "-f", "proteindatabank"]
+    )
+    assert result.exit_code == 0
+    assert path.read_text().startswith("MODEL")
+
+
+def test_smiles2atoms_seed_changes_positions(tmp_path):
+    positions = []
+    for seed in (42, 1234):
+        path = tmp_path / f"conf_{seed}.xyz"
+        result = runner.invoke(
+            app, ["smiles2atoms", "CCO", "-o", str(path), "--seed", str(seed)]
+        )
+        assert result.exit_code == 0
+        positions.append(ase.io.read(path).get_positions())
+
+    assert not (positions[0] == positions[1]).all()
+
+
+def test_smiles2atoms_invalid_smiles():
+    result = runner.invoke(app, ["smiles2atoms", "C(C"])
+    assert result.exit_code == 2
+    assert "C(C" in result.output
+
+
+def test_smiles2atoms_unknown_format(tmp_path):
+    result = runner.invoke(
+        app, ["smiles2atoms", "CCO", "-o", str(tmp_path / "etoh.zzz")]
+    )
+    assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,12 +64,6 @@ def test_smiles2atoms_seed_changes_positions():
     assert not (positions[0] == positions[1]).all()
 
 
-def test_smiles2atoms_invalid_smiles():
-    result = runner.invoke(app, ["smiles2atoms", "C(C"])
-    assert result.exit_code == 2
-    assert "C(C" in result.output
-
-
 @pytest.mark.parametrize("fmt", ["zzz", "cif"])
 def test_smiles2atoms_ase_rejects_format(fmt):
     result = runner.invoke(app, ["smiles2atoms", "CCO", "-f", fmt])

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -123,7 +132,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -315,7 +324,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -385,7 +394,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -636,7 +645,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -794,17 +803,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -819,17 +828,17 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/e6/48c74d54039241a456add616464ea28c6ebf782e4110d419411b83dae06f/ipython-9.7.0.tar.gz", hash = "sha256:5f6de88c905a566c6a9d6c400a8fed54a638e1f7543d17aae2551133216b1e4e", size = 4422115, upload-time = "2025-11-05T12:18:54.646Z" }
 wheels = [
@@ -841,7 +850,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1046,6 +1055,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1218,6 +1239,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1239,6 +1269,7 @@ dependencies = [
     { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packmol" },
     { name = "rdkit" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1270,6 +1301,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.4.2" },
     { name = "packmol", specifier = ">=21.1.2" },
     { name = "rdkit", specifier = ">=2024" },
+    { name = "typer", specifier = ">=0.27.1" },
     { name = "vesin", marker = "extra == 'vesin'", specifier = ">=0.3.7" },
 ]
 provides-extras = ["vesin"]
@@ -2092,6 +2124,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2247,7 +2292,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2306,7 +2351,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -2370,6 +2415,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/70/64b4d7ca92f9cf2e6fc6aaa2eecf80bb9b6b985043a9583f32f8177ea122/scipy-1.16.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ffa6eea95283b2b8079b821dc11f50a17d0571c92b43e2b5b12764dc5f9b285d", size = 38802779, upload-time = "2025-10-28T17:37:59.393Z" },
     { url = "https://files.pythonhosted.org/packages/61/82/8d0e39f62764cce5ffd5284131e109f07cf8955aef9ab8ed4e3aa5e30539/scipy-1.16.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d9f48cafc7ce94cf9b15c6bffdc443a81a27bf7075cf2dcd5c8b40f85d10c4e7", size = 39471128, upload-time = "2025-10-28T17:38:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/64/47/a494741db7280eae6dc033510c319e34d42dd41b7ac0c7ead39354d1a2b5/scipy-1.16.3-cp314-cp314t-win_arm64.whl", hash = "sha256:21d9d6b197227a12dcbf9633320a4e34c6b0e51c57268df255a0942983bac562", size = 26464127, upload-time = "2025-10-28T17:38:11.34Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2619,6 +2673,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a [typer](https://typer.tiangolo.com) based CLI with **one subcommand per public molify function**, starting with `smiles2atoms`. Structures go to standard output, so the CLI composes with redirects and pipes.

```bash
molify smiles2atoms CCO > etoh.xyz
molify smiles2atoms CCO --format PDB | grep ATOM
```

## Why subcommands

`molify pack O:7 CCO:5 --density 1000` slots in later with no redesign. A bare `molify <smiles>` form needs `invoke_without_command=True` plus a callback that guesses whether `pack` is a SMILES string or a mistyped subcommand, which turns every future command into a reserved word in SMILES space and drops the command list from `molify --help`.

Worth knowing for the next command: a Typer app holding exactly one command collapses into that command, so `molify CCO` would work and `molify smiles2atoms CCO` would not. The `@app.callback()`, which also carries `--version`, forces subcommand dispatch.

## Format handling

`--format` accepts an ASE format name or a file extension, in any capitalisation, resolved through ASE's own `extension2format` table. That maps `xyz` onto **extxyz**, the one extension whose target differs from the same-named format, so `--format XYZ` selects the writer that keeps the cell along with `atoms.info`:

```
Properties=species:S:1:pos:R:3 smiles=CCO connectivity="_JSON [[0, 1, 1.0], ...]" pbc="F F F"
```

Those `info` entries read back through `ase.io.read`, so bonds survive the round trip.

The command body stays a pipe, and reporting failures belongs to the libraries: `ase.io` raises for formats it cannot write, and RDKit raises for SMILES it cannot parse.

```python
atoms = _smiles2atoms(smiles, seed=seed)
with io.StringIO() as handle:
    ase.io.write(handle, atoms, format=_resolve_format(fmt))
    sys.stdout.write(handle.getvalue())
```

`StringIO` rather than `BytesIO`, because ASE passes the file object straight to the writer with no text or binary adaptation, and the text writers cover the default format.

## Contents

- `src/molify/cli.py` at 97 lines, plus `[project.scripts] molify = "molify.cli:app"` and `typer` as a dependency
- `src/molify/__main__.py` for `python -m molify`
- `tests/test_cli.py`, 10 tests over format aliases, the extxyz payload, PDB output, `--seed` and unwritable formats
- CLI sections in `README.md` and `docs/source/index.rst`

## Test plan

- [x] `uv run pytest` — 142 passed
- [x] `uvx prek --all-files` — all hooks pass
- [x] `molify smiles2atoms CCO > etoh.xyz` and `--format PDB | grep ATOM` verified in a shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)